### PR TITLE
install the schunk_gripper binary

### DIFF
--- a/ipa325_wsg50/CMakeLists.txt
+++ b/ipa325_wsg50/CMakeLists.txt
@@ -176,11 +176,11 @@ target_link_libraries(schunk_gripper
 # )
 
 ## Mark executables and/or libraries for installation
-# install(TARGETS kuka_lwr kuka_lwr_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(TARGETS schunk_gripper
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
 # install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
for use in packages it is necessary to actually install the binary