### PR TITLE
Fix invalid iterator resulting in 100% cpu load

### DIFF
--- a/ipa325_wsg50/src/WSG50Controller.cpp
+++ b/ipa325_wsg50/src/WSG50Controller.cpp
@@ -204,8 +204,8 @@ void WSG50Controller::Detach(WSG50RosObserver *observer_, unsigned int msgId_)
         std::set< WSG50RosObserver *> observerSet = it->second;
 
         // loop through set and compare the objects
-        //
-        for(setIt = observerSet.begin(); setIt != observerSet.end(); ++setIt)
+        // see https://stackoverflow.com/a/2874533/4270676 how to correctly erase an object while iterating 
+        for(setIt = observerSet.begin(); setIt != observerSet.end(); )
         {
             // get the object from the current position
             WSG50RosObserver * tmpObserver_ = *setIt;
@@ -216,7 +216,10 @@ void WSG50Controller::Detach(WSG50RosObserver *observer_, unsigned int msgId_)
             {
                 // if the objects are equal, delete this object from the set
                 //
-                setIt = observerSet.erase(setIt);                
+                setIt = observerSet.erase(setIt);
+            }
+            else{
+                ++setIt;
             }
         }
 

--- a/ipa325_wsg50/src/WSG50ROSNode.cpp
+++ b/ipa325_wsg50/src/WSG50ROSNode.cpp
@@ -311,10 +311,14 @@ public:
                     response->status_code==E_CMD_FAILED ||
                     response->status_code==E_TIMEOUT) {
                 gpserver_.setAborted(res_);
+                _controller->Detach(this, 0x43);
             } else if(response->status_code==E_SUCCESS) {
                 gpserver_.setSucceeded(res_);
+                _controller->Detach(this, 0x43);
             }
-            _controller->Detach(this, 0x43);
+            else if(response->status_code == E_CMD_PENDING) {
+                // this error is okay, do nothing
+            }            
         } else if(response->id==0x43) { // send feedback response
             fb_.force=_controller->getForce();
             fb_.speed=_controller->getSpeed();
@@ -370,10 +374,14 @@ public:
                     response->status_code==E_CMD_ABORTED ||
                     response->status_code==E_TIMEOUT) {
                 rpserver_.setAborted(res_);
+                _controller->Detach(this, 0x43);
             } else if(response->status_code==E_SUCCESS) {
                 rpserver_.setSucceeded(res_);
+                _controller->Detach(this, 0x43);
+            } else if(response->status_code == E_CMD_PENDING) {
+                // this error is okay, do nothing
             }
-            _controller->Detach(this, 0x43);
+            
         } else if(response->id==0x43) { // send feedback response
             fb_.force=_controller->getForce();
             fb_.speed=_controller->getSpeed();

--- a/ipa325_wsg50/src/WSG50ROSNode.cpp
+++ b/ipa325_wsg50/src/WSG50ROSNode.cpp
@@ -126,7 +126,7 @@ public:
     // Destructor
     virtual ~WSG50HomingAction(void)
     {
-        _controller->Detach(this, 0x21);
+        _controller->Detach(this, 0x20);
     }
 
     // homing action

--- a/ipa325_wsg50/src/WSG50ROSNode.cpp
+++ b/ipa325_wsg50/src/WSG50ROSNode.cpp
@@ -207,7 +207,7 @@ public:
 
     void doPrePositionFingers()
     {
-        if(DEBUG) ROS_INFO("\n\n##########################\n##  Prepositoin Fingers\n##########################");
+        if(DEBUG) ROS_INFO("\n\n##########################\n##  Preposition Fingers\n##########################");
         // accept new goal and get values
         //
         ipa325_wsg50::WSG50PrePositionFingersGoalConstPtr goal;
@@ -421,7 +421,7 @@ void publishStates(const std::string &jointName, const std::string &openingJoint
     _controller->getGraspingStateUpdates(false, true, updatePeriodInMs);
     std::this_thread::sleep_for(std::chrono::milliseconds((TIMEFORWAITINGLOOP*5)));
 
-    ROS_INFO("publishStates(): subscribed to updates of 'widht', 'speed', 'force', 'grasping state'");
+    ROS_INFO("publishStates(): subscribed to updates of 'width', 'speed', 'force', 'grasping state'");
 
     // define publishers
     //


### PR DESCRIPTION
@simonschmeisser 's commit 218a71845b375b7038f50cd1b61027d88c06aee5 unfortunately resulted in an invalid iterator. Each detach lead to one 100% cpu load thread, which caused the driver to die after some operations. 

This pull request fixes this issue and fixes some copy-paste errors and spellings.