### PR TITLE
do not enforce C++11

### DIFF
--- a/ipa325_wsg50/CMakeLists.txt
+++ b/ipa325_wsg50/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(ipa325_wsg50)
 
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
current systems default to C++14 (melodic or noetic) or require C++17 (ros-one). Enforcing C++11 in CMakeLists.txt breaks building on Ubuntu 22.04 / ros-one